### PR TITLE
Fix caching example and update decorator docstring

### DIFF
--- a/gp/utils.py
+++ b/gp/utils.py
@@ -92,6 +92,10 @@ def disk_cache(fn):
     first argument from the cache although it returns different values
     for other arguments.
 
+    WARNING: avoid using the decorator on nested functions as the
+    consistency check will be applied after each decoration thus
+    doubling the runtime.
+
     Parameters
     ----------
     fn : Callable


### PR DESCRIPTION
This PR avoids using a nested function in the caching example thus following the recommendation from the updated docstring ;) 

[edit]
for completeness, quoted from the discussion below:
> it's a scope issue: nested functions are defined and hence decorated each time the outer function is called. as the consistency check is performed on the first execution after decoration it is hence executed on every outer function call which should not be the case for efficient caching

[/edit]