### PR TITLE
Wrap objective function before fitness evaluation to return early if fitness of an individual is not None

### DIFF
--- a/examples/example_caching.py
+++ b/examples/example_caching.py
@@ -39,11 +39,7 @@ def inner_objective(expr):
 
 
 def objective(individual):
-    if individual.fitness is not None:
-        return individual
-
     individual.fitness = -inner_objective(individual.to_sympy())
-
     return individual
 
 

--- a/examples/example_evo_regression.py
+++ b/examples/example_evo_regression.py
@@ -34,9 +34,6 @@ def objective(individual, target_function, seed):
     gp.Individual
         Modified individual with updated fitness value.
     """
-    if individual.fitness is not None:
-        return individual
-
     n_function_evaluations = 1000
 
     np.random.seed(seed)

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import gp
 
@@ -35,3 +36,41 @@ def test_fitness_contains_nan(population_params, genome_params):
     ea = gp.ea.MuPlusLambda(10, 10, 1)
     ea.initialize_fitness_parents(pop, objective)
     ea.step(pop, objective)
+
+
+def _objective_reevaluate_fitness(ind):
+    raise RuntimeError()
+
+
+def test_reevaluate_fitness(ea_params):
+
+    ind = gp.individual.Individual(None, [])
+
+    # first test reevaluate=False
+    ea = gp.ea.MuPlusLambda(**ea_params, n_processes=2, reevaluate_fitness=False)
+
+    # should NOT hit the exception if the fitness of the individual is
+    # NOT None
+    ind.fitness = 1.0
+    ea._compute_fitness([ind], _objective_reevaluate_fitness)
+
+    # should hit the exception if the fitness of the individual is
+    # None
+    ind.fitness = None
+    with pytest.raises(RuntimeError):
+        ea._compute_fitness([ind], _objective_reevaluate_fitness)
+
+    # second test reevaluate=True
+    ea = gp.ea.MuPlusLambda(**ea_params, n_processes=2, reevaluate_fitness=True)
+
+    # should hit the exception if the fitness of the individual is
+    # None
+    ind.fitness = 1.0
+    with pytest.raises(RuntimeError):
+        ea._compute_fitness([ind], _objective_reevaluate_fitness)
+
+    # should hit the exception if the fitness of the individual is
+    # None
+    ind.fitness = None
+    with pytest.raises(RuntimeError):
+        ea._compute_fitness([ind], _objective_reevaluate_fitness)

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -8,9 +8,6 @@ import gp
 
 def _objective_test_population(individual, rng_seed):
 
-    if individual.fitness is not None:
-        return individual
-
     np.random.seed(rng_seed)
 
     n_function_evaluations = 100
@@ -75,10 +72,6 @@ def test_evolve_two_expressions(population_params, ea_params):
     """
 
     def _objective(individual):
-
-        if individual.fitness is not None:
-            return individual
-
         def f0(x):
             return x[0] * (x[0] + x[0])
 


### PR DESCRIPTION
Previously the user needed to implement this early return manually to avoid reevaluating individuals for which the (deterministic) fitness was already calculated. This PR introduces a new parameter for the evolutionary algorithm where the user can decide whether to reevaluate individuals with fitness not None.

After implementing this it's not clear to me whether this is really useful or should just be left to the user and properly documented. It increases the complexity of the module code while (typically) saving only two lines in user code (e.g., https://github.com/Happy-Algorithms-League/python-gp/compare/master...jakobj:enh/only-evaluate-none?expand=1#diff-e26da432872da9fa28a952944b363633L42). Also it can lead to unexpected results for non-deterministic fitness functions if the user overlooks this option. What do you think about this @mschmidt87?