### PR TITLE
Check cache consistency on first decoration, not on first call

### DIFF
--- a/examples/example_caching.py
+++ b/examples/example_caching.py
@@ -18,14 +18,14 @@ def f_target(x):
 
 @gp.utils.disk_cache("example_caching_cache.pkl")
 def inner_objective(expr):
-    """The caching decorator uses the function parameter to identify
-    identical function calls. As many different genotypes produce
-    the same simplified SymPy expression we can use such
-    expressions as an argument to the decorated function to skip
-    reevaluating functionally identical individuals. Note that
-    caching only makes sense for deterministic objective
-    functions, as it assumes that expressions will always return
-    the same fitness values.
+    """The caching decorator uses the function parameters to identify
+    identical function calls. Here, as many different genotypes
+    produce the same simplified SymPy expression we can use such
+    expressions as an argument to the decorated function to avoid
+    reevaluating functionally identical individuals.
+    Note that caching only makes sense for deterministic objective
+    functions, as it assumes that identical expressions will always
+    return the same fitness values.
 
     """
     loss = []

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -29,51 +29,28 @@ def test_cache_decorator():
 def test_cache_decorator_consistency():
 
     cache_fn = tempfile.mkstemp()[1]
+    x = 2
 
     @gp.utils.disk_cache(cache_fn)
     def objective_f(x):
         return x
 
-    @gp.utils.disk_cache(cache_fn)
-    def objective_g(x):
-        return x ** 2
+    # call objective_f once to initialize the cache
+    assert objective_f(x) == pytest.approx(x)
 
+    # decorating a different function with different output using same
+    # filename should raise an error
+    with pytest.raises(RuntimeError):
+
+        @gp.utils.disk_cache(cache_fn)
+        def objective_g(x):
+            return x ** 2
+
+    # decorating a different function with identical output using the
+    # same filename should NOT raise an error
     @gp.utils.disk_cache(cache_fn)
     def objective_h(x):
         return x
-
-    @gp.utils.disk_cache(cache_fn)
-    def objective_f_2d(x, y):
-        return x
-
-    @gp.utils.disk_cache(cache_fn)
-    def objective_f_with_kwargs(x, test=None):
-        return x
-
-    x = 2
-
-    assert objective_f(x) == pytest.approx(x)
-    assert objective_h(x) == pytest.approx(x)
-
-    # calling a different function decorated with same filename but
-    # different output should raise an error
-    with pytest.raises(RuntimeError):
-        objective_g(x)
-
-    # calling a different function decorated with same filename and
-    # same output should not raise an error
-    objective_h(x)
-
-    # calling a different function decorated with same filename and
-    # same output but different arguments should raise an error
-    with pytest.raises(RuntimeError):
-        objective_f_2d(x, x)
-
-    # calling a different function decorated with same filename and
-    # same output but different keyword arguments should raise an
-    # error
-    with pytest.raises(RuntimeError):
-        objective_f_with_kwargs(x, test=2)
 
 
 def objective_history_recording(individual):


### PR DESCRIPTION
This PR makes the caching decorator naturally work with multiprocessing without the need for manual cache checking at the expense of removing an additional check for consistency of (keyword) arguments of decorated functions.

Note that this is a different, in my opinion cleaner and more user friendly, implementation than those discussed in #86 and #91.

closes #91 