### PR TITLE
Replace dictionary in Primitives with tuple and turn Primitives into frozen dataclass

### DIFF
--- a/gp/genome.py
+++ b/gp/genome.py
@@ -22,7 +22,7 @@ class Genome:
         n_columns: int,
         n_rows: int,
         levels_back: int,
-        primitives: List[Type[Node]],
+        primitives: Tuple[Type[Node], ...],
     ) -> None:
         """Init function.
 
@@ -39,8 +39,8 @@ class Genome:
         levels_back : int
             Number of previous columns that an entry in the genome can be
             connected with.
-        primitives : List[Type[Node]]
-           List of primitives that the genome can refer to.
+        primitives : Tuple[Type[Node], ...]
+           Tuple of primitives that the genome can refer to.
         """
         if n_inputs <= 0:
             raise ValueError("n_inputs must be strictly positive")
@@ -232,7 +232,7 @@ class Genome:
 
         for region_idx, hidden_region in self.iter_hidden_regions(dna):
 
-            if hidden_region[0] not in self._primitives.alleles:
+            if not self._primitives.is_valid_allele(hidden_region[0]):
                 raise ValueError("function gene for hidden node has invalid value")
 
             input_genes = hidden_region[1:]
@@ -425,13 +425,14 @@ class Genome:
         -------
         gp.Genome
         """
+
         new = Genome(
             self._n_inputs,
             self._n_outputs,
             self._n_columns,
             self._n_rows,
             self._levels_back,
-            list(self._primitives),
+            tuple(self._primitives),
         )
         new.dna = self._dna.copy()
         return new

--- a/gp/genome.py
+++ b/gp/genome.py
@@ -136,7 +136,7 @@ class Genome:
     ) -> List[int]:
 
         region = []
-        node_id = self._primitives.sample(rng)
+        node_id = self._primitives.sample_allele(rng)
         region.append(node_id)
         region += list(rng.choice(permissable_inputs, self._primitives.max_arity))
 
@@ -404,7 +404,7 @@ class Genome:
         silent_mutation = region_idx not in active_regions
 
         if self._is_function_gene(gene_idx):
-            self._dna[gene_idx] = self._primitives.sample(rng)
+            self._dna[gene_idx] = self._primitives.sample_allele(rng)
             return silent_mutation
 
         else:

--- a/gp/primitives.py
+++ b/gp/primitives.py
@@ -48,18 +48,18 @@ class Primitives:
     def __iter__(self) -> Iterator[Type[Node]]:
         return iter(self._primitives)
 
-    def sample(self, rng: np.random.RandomState) -> int:
-        """Sample a random primitive.
+    def sample_allele(self, rng: np.random.RandomState) -> int:
+        """Sample a random primitive index.
 
         Parameters
         ----------
         rng : numpy.RandomState
-            Random number generator instance to use for crossover.
+            Random number generator instance.
 
         Returns
         -------
         int
-            Index of the sample primitive
+            Index of the sampled primitive.
         """
         return rng.randint(len(self._primitives))
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ def read_extra_requirements():
             extra_requirements[req] = [req]
             extra_requirements["all"].append(req)
 
+    extra_requirements[":python_version == '3.6'"] = ["dataclasses"]
     return extra_requirements
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,7 +15,7 @@ def genome_params():
         "n_columns": 3,
         "n_rows": 3,
         "levels_back": 2,
-        "primitives": [gp.Add, gp.Sub, gp.ConstantFloat],
+        "primitives": (gp.Add, gp.Sub, gp.ConstantFloat),
     }
 
 

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -8,7 +8,7 @@ from gp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
 
 def test_direct_input_output():
     params = {"n_inputs": 1, "n_outputs": 1, "n_columns": 3, "n_rows": 3, "levels_back": 2}
-    primitives = [gp.Add, gp.Sub]
+    primitives = (gp.Add, gp.Sub)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],
@@ -29,7 +29,7 @@ def test_direct_input_output():
 
 
 def test_to_func_simple():
-    primitives = [gp.Add]
+    primitives = (gp.Add,)
     genome = gp.Genome(2, 1, 1, 1, 1, primitives)
 
     genome.dna = [
@@ -54,7 +54,7 @@ def test_to_func_simple():
 
     assert x[0] + x[1] == pytest.approx(y[0])
 
-    primitives = [gp.Sub]
+    primitives = (gp.Sub,)
     genome = gp.Genome(2, 1, 1, 1, 1, primitives)
 
     genome.dna = [
@@ -81,7 +81,7 @@ def test_to_func_simple():
 
 
 def test_compile_two_columns():
-    primitives = [gp.Add, gp.Sub]
+    primitives = (gp.Add, gp.Sub)
     genome = gp.Genome(2, 1, 2, 1, 1, primitives)
 
     genome.dna = [
@@ -111,7 +111,7 @@ def test_compile_two_columns():
 
 
 def test_compile_two_columns_two_rows():
-    primitives = [gp.Add, gp.Sub]
+    primitives = (gp.Add, gp.Sub)
     genome = gp.Genome(2, 2, 2, 2, 1, primitives)
 
     genome.dna = [
@@ -153,7 +153,7 @@ def test_compile_two_columns_two_rows():
 def test_compile_addsubmul():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 2, "n_rows": 2, "levels_back": 1}
 
-    primitives = [gp.Add, gp.Sub, gp.Mul]
+    primitives = (gp.Add, gp.Sub, gp.Mul)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],
@@ -195,7 +195,7 @@ def test_compile_addsubmul():
 
 
 def test_to_numpy():
-    primitives = [gp.Add, gp.Mul, gp.ConstantFloat]
+    primitives = (gp.Add, gp.Mul, gp.ConstantFloat)
     genome = gp.Genome(1, 1, 2, 2, 1, primitives)
     # f(x) = x ** 2 + 1.
     genome.dna = [
@@ -229,7 +229,7 @@ def test_to_numpy():
 
 
 batch_sizes = [1, 10]
-primitives = [gp.Mul, gp.ConstantFloat]
+primitives = (gp.Mul, gp.ConstantFloat)
 genomes = [gp.Genome(1, 1, 2, 2, 1, primitives) for i in range(2)]
 # Function: f(x) = 1*x
 genomes[0].dna = [
@@ -347,7 +347,7 @@ def test_compile_torch_output_shape(genome, batch_size):
 def test_to_sympy():
     sympy = pytest.importorskip("sympy")
 
-    primitives = [gp.Add, gp.ConstantFloat]
+    primitives = (gp.Add, gp.ConstantFloat)
     genome = gp.Genome(1, 1, 2, 2, 1, primitives)
 
     genome.dna = [
@@ -386,7 +386,7 @@ def test_to_sympy():
 def test_catch_invalid_sympy_expr():
     pytest.importorskip("sympy")
 
-    primitives = [gp.Sub, gp.Div]
+    primitives = (gp.Sub, gp.Div)
     genome = gp.Genome(1, 1, 2, 1, 1, primitives)
 
     # x[0] / (x[0] - x[0])
@@ -413,7 +413,7 @@ def test_catch_invalid_sympy_expr():
 def test_allow_powers_of_x_0():
     pytest.importorskip("sympy")
 
-    primitives = [gp.Sub, gp.Mul]
+    primitives = (gp.Sub, gp.Mul)
     genome = gp.Genome(1, 1, 2, 1, 1, primitives)
 
     # x[0] ** 2
@@ -438,7 +438,7 @@ def test_allow_powers_of_x_0():
 def test_input_dim_python(rng_seed):
     rng = np.random.RandomState(rng_seed)
 
-    genome = gp.Genome(2, 1, 1, 1, 1, [gp.ConstantFloat])
+    genome = gp.Genome(2, 1, 1, 1, 1, (gp.ConstantFloat,))
     genome.randomize(rng)
     f = gp.CartesianGraph(genome).to_func()
 
@@ -457,7 +457,7 @@ def test_input_dim_python(rng_seed):
 def test_input_dim_numpy(rng_seed):
     rng = np.random.RandomState(rng_seed)
 
-    genome = gp.Genome(2, 1, 1, 1, 1, [gp.ConstantFloat])
+    genome = gp.Genome(2, 1, 1, 1, 1, (gp.ConstantFloat,))
     genome.randomize(rng)
     f = gp.CartesianGraph(genome).to_numpy()
 
@@ -482,7 +482,7 @@ def test_input_dim_torch(rng_seed):
 
     rng = np.random.RandomState(rng_seed)
 
-    genome = gp.Genome(2, 1, 1, 1, 1, [gp.ConstantFloat])
+    genome = gp.Genome(2, 1, 1, 1, 1, (gp.ConstantFloat,))
     genome.randomize(rng)
     f = gp.CartesianGraph(genome).to_torch()
 
@@ -503,7 +503,7 @@ def test_input_dim_torch(rng_seed):
 
 
 def test_pretty_str():
-    primitives = [gp.Sub, gp.Mul]
+    primitives = (gp.Sub, gp.Mul)
     genome = gp.Genome(1, 1, 2, 1, 1, primitives)
 
     # x[0] ** 2
@@ -534,7 +534,7 @@ def test_pretty_str():
 
 
 def test_pretty_str_with_unequal_inputs_rows_outputs():
-    primitives = [gp.Add]
+    primitives = (gp.Add,)
 
     # less rows than inputs/outputs
     genome = gp.Genome(1, 1, 1, 2, 1, primitives)

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -8,7 +8,7 @@ from gp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
 def test_check_dna_consistency():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
 
-    primitives = [gp.Add]
+    primitives = (gp.Add,)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],
@@ -173,7 +173,7 @@ def test_check_dna_consistency():
 def test_permissable_inputs():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 4, "n_rows": 3, "levels_back": 2}
 
-    primitives = [gp.Add]
+    primitives = (gp.Add,)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],
@@ -210,7 +210,7 @@ def test_permissable_inputs():
 def test_region_iterators():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
 
-    primitives = [gp.Add]
+    primitives = (gp.Add,)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],
@@ -247,7 +247,7 @@ def test_region_iterators():
 def test_check_levels_back_consistency():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 4, "n_rows": 3, "levels_back": None}
 
-    primitives = [gp.Add]
+    primitives = (gp.Add,)
 
     params["levels_back"] = 0
     with pytest.raises(ValueError):
@@ -283,7 +283,7 @@ def test_check_levels_back_consistency():
 
 
 def test_catch_invalid_allele_in_inactive_region():
-    primitives = [gp.ConstantFloat]
+    primitives = (gp.ConstantFloat,)
     genome = gp.Genome(1, 1, 1, 1, 1, primitives)
 
     # should raise error: ConstantFloat node has no inputs, but silent
@@ -295,38 +295,13 @@ def test_catch_invalid_allele_in_inactive_region():
     genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
 
 
-def test_individuals_have_different_genomes(rng_seed):
-
-    population_params = {
-        "n_parents": 5,
-        "n_offspring": 5,
-        "generations": 50000,
-        "n_breeding": 5,
-        "tournament_size": 2,
-        "mutation_rate": 0.05,
-    }
-
-    genome_params = {
-        "n_inputs": 2,
-        "n_outputs": 1,
-        "n_columns": 6,
-        "n_rows": 6,
-        "levels_back": 2,
-        "primitives": [gp.Add, gp.Sub, gp.Mul, gp.Div, gp.ConstantFloat],
-    }
-
+def test_individuals_have_different_genomes(population_params, genome_params, ea_params):
     def objective(ind):
         ind.fitness = ind.idx
         return ind
 
-    pop = gp.Population(
-        population_params["n_parents"], population_params["mutation_rate"], rng_seed, genome_params
-    )
-    ea = gp.ea.MuPlusLambda(
-        population_params["n_offspring"],
-        population_params["n_breeding"],
-        population_params["tournament_size"],
-    )
+    pop = gp.Population(**population_params, genome_params=genome_params)
+    ea = gp.ea.MuPlusLambda(**ea_params)
 
     pop._generate_random_parent_population()
 
@@ -344,7 +319,7 @@ def test_individuals_have_different_genomes(rng_seed):
 
 
 def test_is_gene_in_input_region(rng_seed):
-    genome = gp.Genome(2, 1, 2, 1, None, [gp.Add])
+    genome = gp.Genome(2, 1, 2, 1, None, (gp.Add,))
     rng = np.random.RandomState(rng_seed)
     genome.randomize(rng)
 
@@ -353,7 +328,7 @@ def test_is_gene_in_input_region(rng_seed):
 
 
 def test_is_gene_in_hidden_region(rng_seed):
-    genome = gp.Genome(2, 1, 2, 1, None, [gp.Add])
+    genome = gp.Genome(2, 1, 2, 1, None, (gp.Add,))
     rng = np.random.RandomState(rng_seed)
     genome.randomize(rng)
 
@@ -364,7 +339,7 @@ def test_is_gene_in_hidden_region(rng_seed):
 
 
 def test_is_gene_in_output_region(rng_seed):
-    genome = gp.Genome(2, 1, 2, 1, None, [gp.Add])
+    genome = gp.Genome(2, 1, 2, 1, None, (gp.Add,))
     rng = np.random.RandomState(rng_seed)
     genome.randomize(rng)
 
@@ -374,7 +349,7 @@ def test_is_gene_in_output_region(rng_seed):
 
 def test_mutate_hidden_region(rng_seed):
     rng = np.random.RandomState(rng_seed)
-    genome = gp.Genome(1, 1, 3, 1, None, [gp.Add, gp.ConstantFloat])
+    genome = gp.Genome(1, 1, 3, 1, None, (gp.Add, gp.ConstantFloat))
     dna = [
         ID_INPUT_NODE,
         ID_NON_CODING_GENE,
@@ -423,7 +398,7 @@ def test_mutate_hidden_region(rng_seed):
 
 def test_mutate_output_region(rng_seed):
     rng = np.random.RandomState(rng_seed)
-    genome = gp.Genome(1, 1, 2, 1, None, [gp.Add])
+    genome = gp.Genome(1, 1, 2, 1, None, (gp.Add,))
     genome.dna = [
         ID_INPUT_NODE,
         ID_NON_CODING_GENE,

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -110,7 +110,7 @@ def test_evolve_two_expressions(population_params, ea_params):
             "n_columns": 4,
             "n_rows": 2,
             "levels_back": 2,
-            "primitives": [gp.Add, gp.Mul],
+            "primitives": (gp.Add, gp.Mul),
         },
         {
             "n_inputs": 2,
@@ -118,7 +118,7 @@ def test_evolve_two_expressions(population_params, ea_params):
             "n_columns": 2,
             "n_rows": 2,
             "levels_back": 2,
-            "primitives": [gp.Sub, gp.Mul],
+            "primitives": (gp.Sub, gp.Mul),
         },
     ]
 

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -10,7 +10,7 @@ from gp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
 
 def test_pickle_individual():
 
-    primitives = [gp.Add]
+    primitives = (gp.Add,)
     genome = gp.Genome(1, 1, 1, 1, 1, primitives)
     individual = Individual(None, genome)
 
@@ -20,7 +20,7 @@ def test_pickle_individual():
 
 def test_individual_with_parameter_python():
 
-    primitives = [gp.Add, gp.Parameter]
+    primitives = (gp.Add, gp.Parameter)
     genome = gp.Genome(1, 1, 2, 1, 2, primitives)
     # f(x) = x + c
     genome.dna = [
@@ -58,7 +58,7 @@ def test_individual_with_parameter_python():
 
 def test_individual_with_parameter_torch():
 
-    primitives = [gp.Add, gp.Parameter]
+    primitives = (gp.Add, gp.Parameter)
     genome = gp.Genome(1, 1, 2, 1, 2, primitives)
     # f(x) = x + c
     genome.dna = [
@@ -98,7 +98,7 @@ def test_individual_with_parameter_torch():
 
 def test_individual_with_parameter_sympy():
 
-    primitives = [gp.Add, gp.Parameter]
+    primitives = (gp.Add, gp.Parameter)
     genome = gp.Genome(1, 1, 2, 1, 2, primitives)
     # f(x) = x + c
     genome.dna = [
@@ -135,7 +135,7 @@ def test_individual_with_parameter_sympy():
 
 
 def test_to_and_from_torch_plus_backprop():
-    primitives = [gp.Mul, gp.Parameter]
+    primitives = (gp.Mul, gp.Parameter)
     genome = gp.Genome(1, 1, 2, 2, 1, primitives)
     # f(x) = c * x
     genome.dna = [

--- a/test/test_local_search.py
+++ b/test/test_local_search.py
@@ -7,7 +7,7 @@ from gp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
 def test_gradient_based_step_towards_maximum():
     torch = pytest.importorskip("torch")
 
-    primitives = [gp.Parameter]
+    primitives = (gp.Parameter,)
     genome = gp.Genome(1, 1, 1, 1, 1, primitives)
     # f(x) = c
     genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -7,7 +7,7 @@ from gp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
 def test_add():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
 
-    primitives = [gp.Add]
+    primitives = (gp.Add,)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],
@@ -41,7 +41,7 @@ def test_add():
 def test_sub():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
 
-    primitives = [gp.Sub]
+    primitives = (gp.Sub,)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],
@@ -75,7 +75,7 @@ def test_sub():
 def test_mul():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
 
-    primitives = [gp.Mul]
+    primitives = (gp.Mul,)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],
@@ -109,7 +109,7 @@ def test_mul():
 def test_div():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
 
-    primitives = [gp.Div]
+    primitives = (gp.Div,)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],
@@ -143,7 +143,7 @@ def test_div():
 def test_pow():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
 
-    primitives = [gp.Pow]
+    primitives = (gp.Pow,)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],
@@ -177,7 +177,7 @@ def test_pow():
 def test_constant_float():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
 
-    primitives = [gp.ConstantFloat]
+    primitives = (gp.ConstantFloat,)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],

--- a/test/test_node_factories.py
+++ b/test/test_node_factories.py
@@ -9,7 +9,7 @@ def test_constant_float():
 
     val = 1.678
 
-    primitives = [gp.node_factories.ConstantFloatFactory(val)]
+    primitives = (gp.node_factories.ConstantFloatFactory(val),)
     genome = gp.Genome(
         params["n_inputs"],
         params["n_outputs"],

--- a/test/test_population.py
+++ b/test/test_population.py
@@ -76,20 +76,9 @@ def test_fitness_parents(population_params, genome_params):
     assert np.all(pop.fitness_parents() == pytest.approx(fitness_values))
 
 
-def test_pop_uses_own_rng(rng_seed):
+def test_pop_uses_own_rng(population_params, genome_params, rng_seed):
     """Test independence of Population on global numpy rng.
     """
-
-    population_params = {"n_parents": 5, "mutation_rate": 0.05, "seed": rng_seed}
-
-    genome_params = {
-        "n_inputs": 2,
-        "n_outputs": 1,
-        "n_columns": 3,
-        "n_rows": 3,
-        "levels_back": 2,
-        "primitives": [gp.Add, gp.Sub, gp.Mul, gp.ConstantFloat],
-    }
 
     pop = gp.Population(**population_params, genome_params=genome_params)
 

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -1,23 +1,39 @@
+import dataclasses
 import pytest
 
 import gp
 from gp.primitives import Primitives
 
 
+def test_init_with_list_raises():
+    with pytest.raises(TypeError):
+        Primitives([gp.Add])
+
+
+def test_init_with_instance_raises():
+    with pytest.raises(TypeError):
+        Primitives((gp.Add(0, []),))
+
+
+def test_init_with_wrong_class_raises():
+    with pytest.raises(TypeError):
+        Primitives((list,))
+
+
 def test_immutable_primitives():
-    primitives = Primitives([gp.Add, gp.Sub])
+    primitives = Primitives((gp.Add, gp.Sub))
     with pytest.raises(TypeError):
         primitives[0] = gp.Add
 
-    # currently setting this possible, since MappingProxy which was
-    # used to enforce this behaviour can not be pickled and hence was
-    # removed from Primitives
-    # with pytest.raises(TypeError):
-    #     primitives._primitives[0] = gp.Add
+    with pytest.raises(TypeError):
+        primitives._primitives[0] = gp.Add
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        primitives.primitives = (gp.Add,)
 
 
 def test_max_arity():
-    plain_primitives = [gp.Add, gp.Sub, gp.ConstantFloat]
+    plain_primitives = (gp.Add, gp.Sub, gp.ConstantFloat)
     primitives = Primitives(plain_primitives)
 
     arity = 0
@@ -34,3 +50,13 @@ def test_check_for_correct_class():
 
     with pytest.raises(TypeError):
         Primitives([str])
+
+
+def test_function_indices_remain_fixed_in_list_conversion():
+    plain_primitives = (gp.Add, gp.Sub, gp.Mul, gp.Div)
+    primitives = Primitives(plain_primitives)
+
+    for k in range(10):
+        primitives_clone = Primitives(tuple(primitives))
+        for i in range(len(plain_primitives)):
+            assert primitives[i] == primitives_clone[i]


### PR DESCRIPTION
Instead of using an `OrderedDict` like suggested in #107 this PR replaces the dictionary used in `Primitives` with a list. Since function keys are just integers, they might as well be indices in an array. This automatically avoid a potential relabeling of functions when a `Primitives` object is converted to a list a reinitialized.

Also renames `Primitives.sample` -> `Primitives.sample_allele`.
Also removes some outdated comments.

closes #107 
closes #106 