### PR TITLE
Remove unnecessary "label" arg from `evolve` and `MuPlusLambda`

### DIFF
--- a/gp/hl_api.py
+++ b/gp/hl_api.py
@@ -14,7 +14,6 @@ def evolve(
     min_fitness: float,
     print_progress: Optional[bool] = False,
     callback: Optional[Callable[[Population], None]] = None,
-    label: Optional[str] = None,
     n_processes: int = 1,
 ) -> None:
     """
@@ -40,8 +39,6 @@ def evolve(
     callback :  callable, optional
         Called after each iteration with the population instance.
         Defaults to None.
-    label : str, optional
-        Optional label to be passed to the objective function.
     n_processes : int, optional
         Number of parallel processes to be used. If greater than 1,
         parallel evaluation of the objective is supported. Currently
@@ -52,7 +49,7 @@ def evolve(
     None
     """
 
-    ea.initialize_fitness_parents(pop, objective, label=label)
+    ea.initialize_fitness_parents(pop, objective)
     if callback is not None:
         callback(pop)
 
@@ -61,7 +58,7 @@ def evolve(
     # Main loop: -1 offset since the last loop iteration will still increase generation by one
     while pop.generation < max_generations - 1:
 
-        pop = ea.step(pop, objective, label=label)
+        pop = ea.step(pop, objective)
 
         # progress printing, recording, checking exit condition etc.; needs to
         # be done /after/ new parent population was populated from combined

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -1,12 +1,13 @@
+import functools
 import numpy as np
+import pytest
 
 import gp
 
 
-def test_label(population_params, genome_params):
+def test_objective_with_label(population_params, genome_params):
     def objective_without_label(individual):
-        assert True
-        individual.fitness = -1
+        individual.fitness = -2
         return individual
 
     def objective_with_label(individual, label):
@@ -18,8 +19,13 @@ def test_label(population_params, genome_params):
 
     ea = gp.ea.MuPlusLambda(1, 2, 1)
     ea.initialize_fitness_parents(pop, objective_without_label)
+
     ea.step(pop, objective_without_label)
-    ea.step(pop, objective_with_label, label="test")
+    assert pop.champion.fitness == pytest.approx(-2.0)
+
+    obj = functools.partial(objective_with_label, label="test")
+    ea.step(pop, obj)
+    assert pop.champion.fitness == pytest.approx(-1.0)
 
 
 def test_fitness_contains_nan(population_params, genome_params):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -11,9 +11,9 @@ def test_cache_decorator():
     sleep_time = 0.1
 
     @gp.utils.disk_cache(tempfile.mkstemp()[1])
-    def objective(label):
+    def objective(s):
         time.sleep(sleep_time)  # simulate long execution time
-        return label
+        return s
 
     # first call should take long due to sleep
     t0 = time.time()


### PR DESCRIPTION
As far as I can see this functionality is not necessary and can be easily be replaced by a call to `functools.partial`, no need to maintain this additional complexity.

fixes #104 